### PR TITLE
Security and Database Configuration Updates

### DIFF
--- a/application.properties
+++ b/application.properties
@@ -1,0 +1,13 @@
+spring.datasource.url=jdbc:h2:mem:tarefa_db;DB_CLOSE_DELAY=-1;DB_CLOSE_ON_EXIT=FALSE
+spring.datasource.driverClassName=org.h2.Driver
+spring.datasource.username=sa
+spring.datasource.password=
+
+spring.jpa.database-platform=org.hibernate.dialect.H2Dialect
+spring.jpa.hibernate.ddl-auto=update
+spring.jpa.show-sql=true
+spring.jpa.properties.hibernate.dialect=org.hibernate.dialect.H2Dialect
+spring.jpa.properties.hibernate.hbm2ddl.auto=update
+
+spring.h2.console.enabled=true
+spring.h2.console.path=/h2-console

--- a/pom.xml
+++ b/pom.xml
@@ -1,31 +1,19 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+		 xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
 	<modelVersion>4.0.0</modelVersion>
 	<parent>
 		<groupId>org.springframework.boot</groupId>
 		<artifactId>spring-boot-starter-parent</artifactId>
 		<version>3.4.2</version>
-		<relativePath/> <!-- lookup parent from repository -->
+		<relativePath/>
 	</parent>
 	<groupId>com.tarefaapi</groupId>
 	<artifactId>tarefa-api</artifactId>
 	<version>0.0.1-SNAPSHOT</version>
 	<name>tarefa-api</name>
 	<description>tarefa-api</description>
-	<url/>
-	<licenses>
-		<license/>
-	</licenses>
-	<developers>
-		<developer/>
-	</developers>
-	<scm>
-		<connection/>
-		<developerConnection/>
-		<tag/>
-		<url/>
-	</scm>
+
 	<properties>
 		<java.version>21</java.version>
 	</properties>
@@ -42,15 +30,17 @@
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-starter-web</artifactId>
 		</dependency>
-
-
+		<dependency>
+			<groupId>com.h2database</groupId>
+			<artifactId>h2</artifactId>
+			<scope>runtime</scope>
+		</dependency>
 		<dependency>
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-devtools</artifactId>
 			<scope>runtime</scope>
 			<optional>true</optional>
 		</dependency>
-
 		<dependency>
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-starter-test</artifactId>
@@ -62,24 +52,6 @@
 			<scope>test</scope>
 		</dependency>
 		<dependency>
-			<groupId>org.springframework.boot</groupId>
-			<artifactId>spring-boot-starter-thymeleaf</artifactId>
-		</dependency>
-		<dependency>
-			<groupId>org.mariadb.jdbc</groupId>
-			<artifactId>mariadb-java-client</artifactId>
-			<version>3.5.2</version>
-			<scope>runtime</scope>
-		</dependency>
-		<dependency>
-			<groupId>org.springframework.boot</groupId>
-			<artifactId>spring-boot-test</artifactId>
-		</dependency>
-		<dependency>
-			<groupId>org.springframework.boot</groupId>
-			<artifactId>spring-boot-test-autoconfigure</artifactId>
-		</dependency>
-		<dependency>
 			<groupId>org.testng</groupId>
 			<artifactId>testng</artifactId>
 			<version>RELEASE</version>
@@ -88,17 +60,6 @@
 		<dependency>
 			<groupId>org.junit.jupiter</groupId>
 			<artifactId>junit-jupiter-api</artifactId>
-		</dependency>
-
-		<dependency>
-			<groupId>org.mariadb.jdbc</groupId>
-			<artifactId>mariadb-java-client</artifactId>
-			<version>2.7.4</version>
-		</dependency>
-
-		<dependency>
-			<groupId>org.springframework.boot</groupId>
-			<artifactId>spring-boot-starter-security</artifactId>
 		</dependency>
 	</dependencies>
 
@@ -110,5 +71,4 @@
 			</plugin>
 		</plugins>
 	</build>
-
 </project>

--- a/src/main/java/com/tarefaapi/tarefaapi/model/Tarefa.java
+++ b/src/main/java/com/tarefaapi/tarefaapi/model/Tarefa.java
@@ -3,7 +3,7 @@ package com.tarefaapi.tarefaapi.model;
 import jakarta.persistence.*;
 
 @Entity
-@Table(name = "Tarefas")
+@Table(name = "tarefas")
 public class Tarefa {
 
     @Id

--- a/src/main/java/com/tarefaapi/tarefaapi/security/SecurityConfig.java
+++ b/src/main/java/com/tarefaapi/tarefaapi/security/SecurityConfig.java
@@ -1,0 +1,39 @@
+package com.tarefaapi.tarefaapi.security;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.http.HttpMethod;
+import org.springframework.security.config.Customizer;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+
+
+// Marks this class as a configuration class, meaning it provides Spring Beans
+@Configuration
+
+// Enables Spring Security for this application
+@EnableWebSecurity
+public class SecurityConfig {
+
+    // Defines a security filter chain to control how HTTP requests are secured
+    @Bean
+    public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
+        return http
+                // Disables CSRF protection (Cross-Site Request Forgery)
+                // WARNING: Disabling CSRF is not recommended for production unless you have a good reason
+                .csrf(csrf -> csrf.disable())
+
+                // Specifies that all HTTP requests must be authenticated (i.e., users must log in)
+                .authorizeHttpRequests(auth -> auth
+                        .requestMatchers(HttpMethod.POST, "/securedEndpoint").authenticated()
+                        .anyRequest().permitAll()
+                )
+
+                // Enables basic authentication (username and password in a browser popup)
+                .httpBasic(Customizer.withDefaults())
+
+                // Builds and returns the configured security filter chain
+                .build();
+    }
+}


### PR DESCRIPTION
**This pull request introduces several updates related to security configuration and database setup:**

**Changes Included:**

- **Security Configuration:**

As previously mentioned in the issue, basic security configuration has been added. The /tarefas endpoint is open by default, while the /securedEndpoint requires authentication and will return a 401 Unauthorized error for unauthenticated users.

- **Database Setup:**

As mentioned in the issue, the database configuration has been updated to use H2 for local development and testing. The MariaDB dependencies have been removed, and the table name has been changed to lowercase "tarefas" to comply with H2’s case-sensitivity rules.

**Important Notes:**

These changes are intended for local development and testing using H2. If you plan to use MariaDB for production, you can revert the database configuration to MariaDB by updating the application.properties and pom.xml files accordingly.

I would appreciate it if these changes could be merged into the **security-config** branch for easier integration.